### PR TITLE
fix: derive root package name from dir

### DIFF
--- a/test/lib/fixtures/cp-integration-install_new/dep-graph.json
+++ b/test/lib/fixtures/cp-integration-install_new/dep-graph.json
@@ -11,9 +11,9 @@
   },
   "pkgs": [
     {
-      "id": "_root@0.0.0",
+      "id": "cp-integration-install_new@0.0.0",
       "info": {
-        "name": "_root",
+        "name": "cp-integration-install_new",
         "version": "0.0.0"
       }
     },
@@ -30,7 +30,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "_root@0.0.0",
+        "pkgId": "cp-integration-install_new@0.0.0",
         "deps": [
           {
             "nodeId": "Reachability"

--- a/test/lib/fixtures/eigen/dep-graph.json
+++ b/test/lib/fixtures/eigen/dep-graph.json
@@ -14,9 +14,9 @@
   },
   "pkgs": [
     {
-      "id": "_root@0.0.0",
+      "id": "eigen@0.0.0",
       "info": {
-        "name": "_root",
+        "name": "eigen",
         "version": "0.0.0"
       }
     },
@@ -922,7 +922,7 @@
     "nodes": [
       {
         "nodeId": "root-node",
-        "pkgId": "_root@0.0.0",
+        "pkgId": "eigen@0.0.0",
         "deps": [
           {
             "nodeId": "Aerodramus"


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes #7: 
> The root package name is currently the default `_root`, as given by dep-graph’s DepGraphBuilder. Instead it would be nice to be able to inject this when parsing a lockfile / use the basename of the path when reading a lockfile.

### Notes for the reviewer

Is this the right place to do this?
