### PR TITLE
chore: remove lodash as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/js-yaml": "^3.12.1",
     "core-js": "^3.2.0",
     "js-yaml": "^3.13.1",
-    "lodash": "^4.17.11",
     "snyk": "^1.192.1",
     "source-map-support": "^0.5.7",
     "tslib": "^1.9.3"


### PR DESCRIPTION
This wasn't actually ever used, it must have gotten by accident.