### PR TITLE
feat: implement async LockfileParser.readFile

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -21,6 +21,23 @@ import {
 import 'core-js/features/object/entries';
 
 export default class LockfileParser {
+  public static async readFile(lockfilePath: string): Promise<LockfileParser> {
+    const rootName = path.basename(path.dirname(path.resolve(lockfilePath)));
+    return new Promise((resolve, reject) => {
+      fs.readFile(lockfilePath, { encoding: 'utf8' }, (err, fileContents) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(
+          this.readContents(fileContents, {
+            name: rootName,
+            version: '0.0.0',
+          })
+        );
+      });
+    });
+  }
+
   public static readFileSync(lockfilePath: string): LockfileParser {
     const fileContents = fs.readFileSync(lockfilePath, 'utf8');
     const rootName = path.basename(path.dirname(path.resolve(lockfilePath)));


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Previously this was only implementing a synchronous read function, but this is discouraged practice. This provides now also an asynchronous version.

I switched the integration tests to use the async version and added an additional test which uses the synchronous version.
