### PR TITLE
feat: expose podfileChecksum

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -234,4 +234,10 @@ export default class LockfileParser {
   private get cocoapodsVersion(): string {
     return this.internalData.COCOAPODS || 'unknown';
   }
+
+  /// The checksum of the Podfile, which was used when resolving this integration.
+  /// - Note: this was not tracked by earlier versions of CocoaPods.
+  public get podfileChecksum(): string | undefined {
+    return this.internalData['PODFILE CHECKSUM'];
+  }
 }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -60,3 +60,22 @@ test('LockfileParser.readFileSync reads eigen’s lockfile', () => {
   expect(depGraph.rootPkg.version).toBe('0.0.0');
   expect(depGraph.pkgManager.version).toBe('1.6.0.beta.1');
 });
+
+describe('LockfileParser.podfileChecksum', () => {
+  test('returns eigen’s Podfile checksum', () => {
+    const filePath = path.join(fixtureDir('eigen'), 'Podfile.lock');
+    const parser = LockfileParser.readFileSync(filePath);
+    expect(parser.podfileChecksum).toBe(
+      '23ca0886a0a3ae6b1e8abd87c2fb243b24ab9f2b'
+    );
+  });
+
+  test('returns undefined if there is no Podfile checksum', () => {
+    const filePath = path.join(
+      fixtureDir('cp-integration-install_new'),
+      'Podfile.lock'
+    );
+    const parser = LockfileParser.readFileSync(filePath);
+    expect(parser.podfileChecksum).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Expose the existing getter to get the parsed checksum of a podfile.