### PR TITLE
fix: export LockfileParser only via named export

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
 import LockfileParser from './lockfile-parser';
 
-export default LockfileParser;
+export { LockfileParser };

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { DepGraph, createFromJSON } from '@snyk/dep-graph';
-import LockfileParser from '../../lib';
+import { LockfileParser } from '../../lib';
 
 const regenerateFixtures = process.env.REGENERATE == 'true';
 


### PR DESCRIPTION
BREAKING CHANGE: this removes the default export and changes the exported interface of this library.

Fixes #6.

- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)