### PR TITLE
fix: correctly fail on parse error

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -28,12 +28,15 @@ export default class LockfileParser {
         if (err) {
           reject(err);
         }
-        resolve(
-          this.readContents(fileContents, {
+        try {
+          const parser = this.readContents(fileContents, {
             name: rootName,
             version: '0.0.0',
-          })
-        );
+          });
+          resolve(parser);
+        } catch (err) {
+          reject(err);
+        }
       });
     });
   }

--- a/test/lib/fixtures/lockfile_in_conflict/Podfile.lock
+++ b/test/lib/fixtures/lockfile_in_conflict/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Reachability (3.1.0)
+
+DEPENDENCIES:
+<<<<<<< HEAD
+  - Reachability (= 3.1.0)
+=======
+  - Reachability (~> 3.0.0)
+>>>>>>> c001bada55d00dc0dedabad1dea011c00ldecaf1
+
+SPEC REPOS:
+  trunk:
+    - Reachability
+
+SPEC CHECKSUMS:
+  Reachability: 3c8fe9643e52184d17f207e781cd84158da8c02b

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -61,6 +61,16 @@ test('LockfileParser.readFileSync reads eigen’s lockfile', () => {
   expect(depGraph.pkgManager.version).toBe('1.6.0.beta.1');
 });
 
+test('LockfileParser.readFile with invalid lockfile', async () => {
+  const filePath = path.join(
+    fixtureDir('lockfile_in_conflict'),
+    'Podfile.lock'
+  );
+  await expect(LockfileParser.readFile(filePath)).rejects.toThrowError(
+    /^can not read a block mapping entry; a multiline key may not be an implicit key at line 11, column 11/
+  );
+});
+
 describe('LockfileParser.podfileChecksum', () => {
   test('returns eigen’s Podfile checksum', () => {
     const filePath = path.join(fixtureDir('eigen'), 'Podfile.lock');


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Without this, it's not possible to catch parse exceptions as expected, because they were thrown synchronous in asynchronous code.