### PR TITLE
fix: support specs with platform-specific transitives

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -88,7 +88,7 @@ export default class LockfileParser {
         pkgDeps = elem[objKey].map(pkgInfoFromDependencyString);
       }
 
-      const nodeId = pkgInfo.name;
+      const nodeId = this.nodeIdForPkgInfo(pkgInfo);
       builder.addPkgNode(pkgInfo, nodeId, {
         labels: this.nodeInfoLabelsForPod(pkgInfo.name),
       });

--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -107,7 +107,15 @@ export default class LockfileParser {
     // Now we can start to connect dependencies
     Object.entries(allDeps).forEach(([nodeId, pkgDeps]) =>
       pkgDeps.forEach((pkgInfo) => {
-        builder.connectDep(nodeId, this.nodeIdForPkgInfo(pkgInfo));
+        const depNodeId = this.nodeIdForPkgInfo(pkgInfo);
+        if (!allDeps[depNodeId]) {
+          // The pod is not a direct dependency of any targets of the integration,
+          // which can happen for platform-specific transitives, when their platform
+          // is not used in any target. (e.g. PromiseKit/UIKit is iOS-specific and is
+          // a transitive of PromiseKit, but won't be included for a macOS project.)
+          return;
+        }
+        builder.connectDep(nodeId, depNodeId);
       })
     );
 

--- a/test/lib/fixtures/iina/Podfile.lock
+++ b/test/lib/fixtures/iina/Podfile.lock
@@ -1,0 +1,51 @@
+PODS:
+  - GRMustache.swift (2.0.0)
+  - GzipSwift (5.0.0)
+  - Just (0.7.1)
+  - PromiseKit (6.8.4):
+    - PromiseKit/CorePromise (= 6.8.4)
+    - PromiseKit/Foundation (= 6.8.4)
+    - PromiseKit/UIKit (= 6.8.4)
+  - PromiseKit/CorePromise (6.8.4)
+  - PromiseKit/Foundation (6.8.4):
+    - PromiseKit/CorePromise
+  - Sparkle (1.21.3)
+
+DEPENDENCIES:
+  - GRMustache.swift (from `https://github.com/iina/GRMustache.swift`)
+  - GzipSwift
+  - Just (from `https://github.com/iina/Just`, branch `swift-5`)
+  - PromiseKit
+  - Sparkle
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - GzipSwift
+    - PromiseKit
+    - Sparkle
+
+EXTERNAL SOURCES:
+  GRMustache.swift:
+    :git: https://github.com/iina/GRMustache.swift
+  Just:
+    :branch: swift-5
+    :git: https://github.com/iina/Just
+
+CHECKOUT OPTIONS:
+  GRMustache.swift:
+    :commit: a46e65d00b4753449b90465be813bbdb1a9ffc9d
+    :git: https://github.com/iina/GRMustache.swift
+  Just:
+    :commit: d0ae3f9bc2d6bf247b19217764a096bbac55f007
+    :git: https://github.com/iina/Just
+
+SPEC CHECKSUMS:
+  GRMustache.swift: 53405b02c374520f9193cf41bfa677f03a6d70aa
+  GzipSwift: 5592f4d62b641e04d06443ba471f8ed76b1363e4
+  Just: 60c0995e04718eb621a07abef45ce6883c562f2b
+  PromiseKit: 51794a832647e7b819336dc2279039ce9f1cc49b
+  Sparkle: 3f75576db8b0265adef36c43249d747f22d0b708
+
+PODFILE CHECKSUM: 4969f0d73fe5d871a1a1853ad7807a345443e71a
+
+COCOAPODS: 1.7.5

--- a/test/lib/fixtures/iina/dep-graph.json
+++ b/test/lib/fixtures/iina/dep-graph.json
@@ -1,0 +1,189 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "CocoaPods",
+    "version": "1.7.5",
+    "repositories": [
+      {
+        "alias": "https://github.com/cocoapods/specs.git"
+      }
+    ]
+  },
+  "pkgs": [
+    {
+      "id": "iina@0.0.0",
+      "info": {
+        "name": "iina",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "GRMustache.swift@2.0.0",
+      "info": {
+        "name": "GRMustache.swift",
+        "version": "2.0.0"
+      }
+    },
+    {
+      "id": "GzipSwift@5.0.0",
+      "info": {
+        "name": "GzipSwift",
+        "version": "5.0.0"
+      }
+    },
+    {
+      "id": "Just@0.7.1",
+      "info": {
+        "name": "Just",
+        "version": "0.7.1"
+      }
+    },
+    {
+      "id": "PromiseKit@6.8.4",
+      "info": {
+        "name": "PromiseKit",
+        "version": "6.8.4"
+      }
+    },
+    {
+      "id": "PromiseKit/CorePromise@6.8.4",
+      "info": {
+        "name": "PromiseKit/CorePromise",
+        "version": "6.8.4"
+      }
+    },
+    {
+      "id": "PromiseKit/Foundation@6.8.4",
+      "info": {
+        "name": "PromiseKit/Foundation",
+        "version": "6.8.4"
+      }
+    },
+    {
+      "id": "Sparkle@1.21.3",
+      "info": {
+        "name": "Sparkle",
+        "version": "1.21.3"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "iina@0.0.0",
+        "deps": [
+          {
+            "nodeId": "GRMustache.swift"
+          },
+          {
+            "nodeId": "GzipSwift"
+          },
+          {
+            "nodeId": "Just"
+          },
+          {
+            "nodeId": "PromiseKit"
+          },
+          {
+            "nodeId": "Sparkle"
+          }
+        ]
+      },
+      {
+        "nodeId": "GRMustache.swift",
+        "pkgId": "GRMustache.swift@2.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "53405b02c374520f9193cf41bfa677f03a6d70aa",
+            "externalSourceGit": "https://github.com/iina/GRMustache.swift",
+            "checkoutOptionsGit": "https://github.com/iina/GRMustache.swift",
+            "checkoutOptionsCommit": "a46e65d00b4753449b90465be813bbdb1a9ffc9d"
+          }
+        }
+      },
+      {
+        "nodeId": "GzipSwift",
+        "pkgId": "GzipSwift@5.0.0",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "5592f4d62b641e04d06443ba471f8ed76b1363e4",
+            "repository": "https://github.com/cocoapods/specs.git"
+          }
+        }
+      },
+      {
+        "nodeId": "Just",
+        "pkgId": "Just@0.7.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "60c0995e04718eb621a07abef45ce6883c562f2b",
+            "externalSourceGit": "https://github.com/iina/Just",
+            "externalSourceBranch": "swift-5",
+            "checkoutOptionsGit": "https://github.com/iina/Just",
+            "checkoutOptionsCommit": "d0ae3f9bc2d6bf247b19217764a096bbac55f007"
+          }
+        }
+      },
+      {
+        "nodeId": "PromiseKit",
+        "pkgId": "PromiseKit@6.8.4",
+        "deps": [
+          {
+            "nodeId": "PromiseKit/CorePromise"
+          },
+          {
+            "nodeId": "PromiseKit/Foundation"
+          }
+        ],
+        "info": {
+          "labels": {
+            "checksum": "51794a832647e7b819336dc2279039ce9f1cc49b",
+            "repository": "https://github.com/cocoapods/specs.git"
+          }
+        }
+      },
+      {
+        "nodeId": "PromiseKit/CorePromise",
+        "pkgId": "PromiseKit/CorePromise@6.8.4",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "51794a832647e7b819336dc2279039ce9f1cc49b",
+            "repository": "https://github.com/cocoapods/specs.git"
+          }
+        }
+      },
+      {
+        "nodeId": "PromiseKit/Foundation",
+        "pkgId": "PromiseKit/Foundation@6.8.4",
+        "deps": [
+          {
+            "nodeId": "PromiseKit/CorePromise"
+          }
+        ],
+        "info": {
+          "labels": {
+            "checksum": "51794a832647e7b819336dc2279039ce9f1cc49b",
+            "repository": "https://github.com/cocoapods/specs.git"
+          }
+        }
+      },
+      {
+        "nodeId": "Sparkle",
+        "pkgId": "Sparkle@1.21.3",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "3f75576db8b0265adef36c43249d747f22d0b708",
+            "repository": "https://github.com/cocoapods/specs.git"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -52,6 +52,7 @@ fixtureTest(
   'cp-integration-install_new'
 );
 fixtureTest('Parse Penc’s Podfile.lock', 'penc');
+fixtureTest('Parse iina’s Podfile.lock', 'iina');
 
 test('LockfileParser.readFileSync reads eigen’s lockfile', () => {
   const filePath = path.join(fixtureDir('eigen'), 'Podfile.lock');


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This supports the case where the pod is not a direct dependency of any targets of the integration, which can happen for platform-specific transitives, when their platform is not used in any target. (e.g. PromiseKit/UIKit is iOS-specific and is a transitive of PromiseKit, but won't be included for a macOS-only integration.)

/c @arielorn 