### PR TITLE
fix: support older lockfiles which miss spec repos

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,7 +25,7 @@ export interface NodeInfoLabels {
 export interface Lockfile {
   PODS: PodEntry[];
   DEPENDENCIES: string[];
-  'SPEC REPOS': {
+  'SPEC REPOS'?: {
     [key: string]: string[];
   };
   'EXTERNAL SOURCES'?: {

--- a/test/lib/fixtures/penc/Podfile.lock
+++ b/test/lib/fixtures/penc/Podfile.lock
@@ -1,0 +1,28 @@
+PODS:
+  - Silica (0.1.5)
+  - Sparkle (1.18.1)
+  - SwiftyBeaver (1.4.2)
+
+DEPENDENCIES:
+  - Silica (from `https://github.com/ianyh/Silica.git`, tag `0.1.5`)
+  - Sparkle
+  - SwiftyBeaver
+
+EXTERNAL SOURCES:
+  Silica:
+    :git: https://github.com/ianyh/Silica.git
+    :tag: 0.1.5
+
+CHECKOUT OPTIONS:
+  Silica:
+    :git: https://github.com/ianyh/Silica.git
+    :tag: 0.1.5
+
+SPEC CHECKSUMS:
+  Silica: 3b5a774469476ef84fe9d96a63bfe09908654e50
+  Sparkle: 06ea33170007c5937ee54da481b4481af98fac79
+  SwiftyBeaver: 91057725648ee4980308f1650af077d04b3654a0
+
+PODFILE CHECKSUM: 56045e819fdcab3669f1847a1bc88e6702accf51
+
+COCOAPODS: 1.3.1

--- a/test/lib/fixtures/penc/dep-graph.json
+++ b/test/lib/fixtures/penc/dep-graph.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "CocoaPods",
+    "version": "1.3.1",
+    "repositories": []
+  },
+  "pkgs": [
+    {
+      "id": "penc@0.0.0",
+      "info": {
+        "name": "penc",
+        "version": "0.0.0"
+      }
+    },
+    {
+      "id": "Silica@0.1.5",
+      "info": {
+        "name": "Silica",
+        "version": "0.1.5"
+      }
+    },
+    {
+      "id": "Sparkle@1.18.1",
+      "info": {
+        "name": "Sparkle",
+        "version": "1.18.1"
+      }
+    },
+    {
+      "id": "SwiftyBeaver@1.4.2",
+      "info": {
+        "name": "SwiftyBeaver",
+        "version": "1.4.2"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "penc@0.0.0",
+        "deps": [
+          {
+            "nodeId": "Silica"
+          },
+          {
+            "nodeId": "Sparkle"
+          },
+          {
+            "nodeId": "SwiftyBeaver"
+          }
+        ]
+      },
+      {
+        "nodeId": "Silica",
+        "pkgId": "Silica@0.1.5",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "3b5a774469476ef84fe9d96a63bfe09908654e50",
+            "externalSourceGit": "https://github.com/ianyh/Silica.git",
+            "externalSourceTag": "0.1.5",
+            "checkoutOptionsGit": "https://github.com/ianyh/Silica.git",
+            "checkoutOptionsTag": "0.1.5"
+          }
+        }
+      },
+      {
+        "nodeId": "Sparkle",
+        "pkgId": "Sparkle@1.18.1",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "06ea33170007c5937ee54da481b4481af98fac79"
+          }
+        }
+      },
+      {
+        "nodeId": "SwiftyBeaver",
+        "pkgId": "SwiftyBeaver@1.4.2",
+        "deps": [],
+        "info": {
+          "labels": {
+            "checksum": "91057725648ee4980308f1650af077d04b3654a0"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -51,6 +51,7 @@ fixtureTest(
   'CocoaPods’ integration spec install_new',
   'cp-integration-install_new'
 );
+fixtureTest('Parse Penc’s Podfile.lock', 'penc');
 
 test('LockfileParser.readFileSync reads eigen’s lockfile', () => {
   const filePath = path.join(fixtureDir('eigen'), 'Podfile.lock');


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This adds support for older lockfiles which do not contain the spec repositories yet. This caused an issue for @arielorn, where the snyk CLI failed with:
```
Cannot convert undefined or null to object
```
