### PR TITLE
fix: Change package manager name from `CocoaPods` to `cocoapods`

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -246,7 +246,7 @@ export default class LockfileParser {
 
   private get pkgManager(): PkgManager {
     return {
-      name: 'CocoaPods',
+      name: 'cocoapods',
       version: this.cocoapodsVersion,
       repositories: this.repositories,
     };

--- a/test/lib/fixtures/cp-integration-install_new/dep-graph.json
+++ b/test/lib/fixtures/cp-integration-install_new/dep-graph.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.2.0",
   "pkgManager": {
-    "name": "CocoaPods",
+    "name": "cocoapods",
     "version": "unknown",
     "repositories": [
       {

--- a/test/lib/fixtures/eigen/dep-graph.json
+++ b/test/lib/fixtures/eigen/dep-graph.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.2.0",
   "pkgManager": {
-    "name": "CocoaPods",
+    "name": "cocoapods",
     "version": "1.6.0.beta.1",
     "repositories": [
       {

--- a/test/lib/fixtures/iina/dep-graph.json
+++ b/test/lib/fixtures/iina/dep-graph.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.2.0",
   "pkgManager": {
-    "name": "CocoaPods",
+    "name": "cocoapods",
     "version": "1.7.5",
     "repositories": [
       {

--- a/test/lib/fixtures/penc/dep-graph.json
+++ b/test/lib/fixtures/penc/dep-graph.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.2.0",
   "pkgManager": {
-    "name": "CocoaPods",
+    "name": "cocoapods",
     "version": "1.3.1",
     "repositories": []
   },


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

BREAKING CHANGE: package manager name changed to `cocoapods`

### Notes for the reviewer

- `name` should really be `identifier` (in dep-graph lib)
