### PR TITLE
feat: generate es2015 code for node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "core-js": "^3.2.0",
     "js-yaml": "^3.13.1",
     "source-map-support": "^0.5.7",
-    "tslib": "^1.9.3"
+    "tslib": "^1.10.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",
@@ -56,7 +56,7 @@
     "tsc-watch": "^2.2.1",
     "tslint": "5.11.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.4.1"
+    "typescript": "^3.7.3"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "es5",
+    "target": "es2015",
     "lib": ["es6", "es2016.array.include", "es2017.object"],
     "module": "commonjs",
     "sourceMap": true,


### PR DESCRIPTION
This removes some uses of tslib's promises from the generated code,
and generally cleans up stack traces and error messages.
