### PR TITLE
feat: use latest @snyk/dep-graph that drops vulnerable lodash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ notifications:
   email: false
 language: node_js
 node_js:
+  - '12'
   - '10'
   - '8'
-  - '6'
 cache: npm
 stages:
   - lint

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,9 @@ cache:
 
 environment:
   matrix:
+    - nodejs_version: '12'
+    - nodejs_version: '10'
     - nodejs_version: '8'
-    - nodejs_version: '6'
-    - nodejs_version: '4'
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "homepage": "https://github.com/snyk/cocoapods-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/dep-graph": "^1.11.0",
+    "@snyk/dep-graph": "1.18.2",
     "@snyk/ruby-semver": "^2.0.4",
     "@types/js-yaml": "^3.12.1",
     "core-js": "^3.2.0",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Use patched @snyk/graphlib to remove vulnerable lodash
https://github.com/snyk/snyk/pull/1093