### PR TITLE
feat: bump @snyk/ruby-semver

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -53,7 +53,7 @@ export default class LockfileParser {
     contents: string,
     rootPkgInfo?: PkgInfo
   ): LockfileParser {
-    return new LockfileParser(yaml.safeLoad(contents), rootPkgInfo);
+    return new LockfileParser(yaml.safeLoad(contents) as Lockfile, rootPkgInfo);
   }
 
   private rootPkgInfo: PkgInfo | undefined = undefined;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ts-jest": "^25.5.1",
     "ts-node": "8.10.1",
     "tsc-watch": "^4.2.3",
-    "typescript": "^3.8.3"
+    "typescript": "~3.8.3"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
     "ts-jest": "^25.5.1",
-    "ts-node": "8.10.1",
     "tsc-watch": "^4.2.3",
     "typescript": "~3.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/snyk/cocoapods-lockfile-parser#readme",
   "dependencies": {
     "@snyk/dep-graph": "1.19.0",
-    "@snyk/ruby-semver": "^2.0.4",
+    "@snyk/ruby-semver": "^3.0.0",
     "@types/js-yaml": "^3.12.1",
     "js-yaml": "^3.13.1",
     "source-map-support": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "devDependencies": {
     "@types/jest": "^25.2.1",
     "@types/node": "^8.10.60",
-    "@typescript-eslint/eslint-plugin": "^2.32.0",
-    "@typescript-eslint/parser": "^2.32.0",
+    "@typescript-eslint/eslint-plugin": "^3.6.1",
+    "@typescript-eslint/parser": "^3.6.1",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
     "husky": "^4.2.5",


### PR DESCRIPTION
### What this does

Upgrade `@snyk/ruby-semver`, which has a major version bump because it has types.

Fix a couple of build errors/warnings.