### PR TITLE
fix: update dep-graph to use upstream lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   ],
   "homepage": "https://github.com/snyk/cocoapods-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/dep-graph": "1.19.3",
-    "@snyk/ruby-semver": "^3.0.0",
+    "@snyk/dep-graph": "1.19.4",
     "@types/js-yaml": "^3.12.1",
     "js-yaml": "^3.13.1",
     "source-map-support": "^0.5.7",


### PR DESCRIPTION
Updating dep-graph to prevent including our lodash fork.

I think the ruby-semver was included by mistake? 