### PR TITLE
feat: drop source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "homepage": "https://github.com/snyk/cocoapods-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/dep-graph": "1.19.4",
+    "@snyk/dep-graph": "1.20.0",
     "@types/js-yaml": "^3.12.1",
     "js-yaml": "^3.13.1",
     "source-map-support": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@snyk/dep-graph": "1.20.0",
     "@types/js-yaml": "^3.12.1",
     "js-yaml": "^3.13.1",
-    "source-map-support": "^0.5.7",
     "tslib": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### What this does

We're not using the `source-map-support` library, and we shouldn't be. Stop declaring a dependence on it. It's for applications, not libraries.

Also pick up a minor release of `@snyk/dep-graph`, which we have pinned. This version bump brings the same removal of `source-map-support`, but their case is even worse; they're initialising the library, which is bad.