### PR TITLE
Use latest @snyk/dep-graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "homepage": "https://github.com/snyk/cocoapods-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/dep-graph": "^1.21.0",
+    "@snyk/dep-graph": "^1.23.1",
     "@types/js-yaml": "^3.12.1",
     "js-yaml": "^3.13.1",
     "tslib": "^1.10.0"


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Bumps to the latest version of `@snyk/dep-graph` which to reduce lodash exposure.

### Additional Context
https://snyk.slack.com/archives/C01MDU3UL59
