### PR TITLE
feat: new @snyk/dep-graph (no more node 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "homepage": "https://github.com/snyk/cocoapods-lockfile-parser#readme",
   "dependencies": {
-    "@snyk/dep-graph": "^1.23.1",
+    "@snyk/dep-graph": "^2.3.0",
     "@types/js-yaml": "^3.12.1",
     "js-yaml": "^3.13.1",
     "tslib": "^1.10.0"


### PR DESCRIPTION
### What this does

Upgrade to the recent version of @snyk/dep-graph, which has dropped support for node 8, which we haven't cared about for a long time.