### PR TITLE
fix: force string node info labels

### DIFF
--- a/lib/lockfile-parser.ts
+++ b/lib/lockfile-parser.ts
@@ -53,7 +53,12 @@ export default class LockfileParser {
     contents: string,
     rootPkgInfo?: PkgInfo
   ): LockfileParser {
-    return new LockfileParser(yaml.safeLoad(contents) as Lockfile, rootPkgInfo);
+    return new LockfileParser(
+      yaml.safeLoad(contents, {
+        schema: yaml.FAILSAFE_SCHEMA,
+      }) as Lockfile,
+      rootPkgInfo
+    );
   }
 
   private rootPkgInfo: PkgInfo | undefined = undefined;
@@ -80,7 +85,7 @@ export default class LockfileParser {
         pkgDeps = [];
       } else {
         // When there are dependencies. This equals in yaml e.g.
-        //    - React/Core (0.59.2):
+        //    - React/Core (0.59.2):
         //      - yoga (= 0.59.2.React)
         const objKey = Object.keys(elem)[0];
         pkgInfo = pkgInfoFromSpecificationString(objKey);
@@ -131,14 +136,14 @@ export default class LockfileParser {
   /// them into the expected labels data structure.
   private nodeInfoLabelsForPod(podName: string): NodeInfoLabels {
     let nodeInfoLabels: NodeInfoLabels = {
-      checksum: this.checksumForPod(podName),
+      checksum: asString(this.checksumForPod(podName)) as string,
     };
 
     const repository = this.repositoryForPod(podName);
     if (repository) {
       nodeInfoLabels = {
         ...nodeInfoLabels,
-        repository,
+        repository: asString(repository),
       };
     }
 
@@ -146,12 +151,12 @@ export default class LockfileParser {
     if (externalSourceInfo) {
       nodeInfoLabels = {
         ...nodeInfoLabels,
-        externalSourcePodspec: externalSourceInfo[':podspec'],
-        externalSourcePath: externalSourceInfo[':path'],
-        externalSourceGit: externalSourceInfo[':git'],
-        externalSourceTag: externalSourceInfo[':tag'],
-        externalSourceCommit: externalSourceInfo[':commit'],
-        externalSourceBranch: externalSourceInfo[':branch'],
+        externalSourcePodspec: asString(externalSourceInfo[':podspec']),
+        externalSourcePath: asString(externalSourceInfo[':path']),
+        externalSourceGit: asString(externalSourceInfo[':git']),
+        externalSourceTag: asString(externalSourceInfo[':tag']),
+        externalSourceCommit: asString(externalSourceInfo[':commit']),
+        externalSourceBranch: asString(externalSourceInfo[':branch']),
       };
     }
 
@@ -159,12 +164,12 @@ export default class LockfileParser {
     if (checkoutOptions) {
       nodeInfoLabels = {
         ...nodeInfoLabels,
-        checkoutOptionsPodspec: checkoutOptions[':podspec'],
-        checkoutOptionsPath: checkoutOptions[':path'],
-        checkoutOptionsGit: checkoutOptions[':git'],
-        checkoutOptionsTag: checkoutOptions[':tag'],
-        checkoutOptionsCommit: checkoutOptions[':commit'],
-        checkoutOptionsBranch: checkoutOptions[':branch'],
+        checkoutOptionsPodspec: asString(checkoutOptions[':podspec']),
+        checkoutOptionsPath: asString(checkoutOptions[':path']),
+        checkoutOptionsGit: asString(checkoutOptions[':git']),
+        checkoutOptionsTag: asString(checkoutOptions[':tag']),
+        checkoutOptionsCommit: asString(checkoutOptions[':commit']),
+        checkoutOptionsBranch: asString(checkoutOptions[':branch']),
       };
     }
 
@@ -254,12 +259,19 @@ export default class LockfileParser {
   /// The CocoaPods version encoded in the lockfile which was used to
   /// create this resolution.
   private get cocoapodsVersion(): string {
-    return this.internalData.COCOAPODS || 'unknown';
+    return asString(this.internalData.COCOAPODS) || 'unknown';
   }
 
   /// The checksum of the Podfile, which was used when resolving this integration.
   /// - Note: this was not tracked by earlier versions of CocoaPods.
   public get podfileChecksum(): string | undefined {
-    return this.internalData['PODFILE CHECKSUM'];
+    return asString(this.internalData['PODFILE CHECKSUM']);
   }
+}
+
+function asString(value: unknown): string | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  return String(value);
 }

--- a/test/lib/fixtures/branch_underscore_yaml_coercion/Podfile.lock
+++ b/test/lib/fixtures/branch_underscore_yaml_coercion/Podfile.lock
@@ -1,0 +1,44 @@
+PODS:
+  - AFNetworkActivityLogger (3.0.0):
+    - AFNetworking/NSURLSession (~> 3.0)
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
+    - AFNetworking/Reachability
+    - AFNetworking/Security
+    - AFNetworking/Serialization
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
+    - AFNetworking/NSURLSession
+
+DEPENDENCIES:
+  - AFNetworkActivityLogger (from `https://github.com/AFNetworking/AFNetworkActivityLogger.git`, branch `3_0_0`)
+  - AFNetworking (= 3.1.0)
+
+SPEC REPOS:
+  trunk:
+    - AFNetworking
+
+EXTERNAL SOURCES:
+  AFNetworkActivityLogger:
+    :branch: 3_0_0
+    :git: https://github.com/AFNetworking/AFNetworkActivityLogger.git
+
+CHECKOUT OPTIONS:
+  AFNetworkActivityLogger:
+    :commit: b7cce59a369788c409d218e8dab7f381a858cee4
+    :git: https://github.com/AFNetworking/AFNetworkActivityLogger.git
+
+SPEC CHECKSUMS:
+  AFNetworkActivityLogger: e77f68d014becb33c4306a23f56a64906ff72670
+  AFNetworking: 19827bce8c8d25b16bea185837cb66976c23f8fe
+
+PODFILE CHECKSUM: 8d312495be0bc880b90786d23d7a12d5b6865d99
+
+COCOAPODS: 1.15.2

--- a/test/lib/yaml-coercion.test.ts
+++ b/test/lib/yaml-coercion.test.ts
@@ -1,0 +1,98 @@
+import * as path from 'path';
+import { LockfileParser } from '../../lib';
+
+function fixtureDir(dir: string): string {
+  return `${__dirname}/fixtures/${dir}`;
+}
+
+describe('YAML 1.1 scalar coercion in lockfile labels', () => {
+  describe('branch_underscore_yaml_coercion fixture', () => {
+    // The fixture's Podfile.lock contains:
+    //   EXTERNAL SOURCES:
+    //     AFNetworkActivityLogger:
+    //       :branch: 3_0_0
+    //
+    // `js-yaml` 3.x parses YAML 1.1 Core schema, where `_` is a digit
+    // separator inside numeric scalars. Without coercion, `:branch: 3_0_0`
+    // is loaded as the integer `300` and would leak into the depgraph
+    // label as a number, even though the TypeScript type declares it `string`.
+    const filePath = path.join(
+      fixtureDir('branch_underscore_yaml_coercion'),
+      'Podfile.lock'
+    );
+
+    test('externalSourceBranch is the original string `3_0_0`', () => {
+      const parser = LockfileParser.readFileSync(filePath);
+      const dg = parser.toDepGraph().toJSON();
+      const node = dg.graph.nodes.find(
+        (n) => n.nodeId === 'AFNetworkActivityLogger'
+      );
+      expect(node).toBeDefined();
+      expect(node!.info!.labels!.externalSourceBranch).toBe('3_0_0');
+      expect(typeof node!.info!.labels!.externalSourceBranch).toBe('string');
+    });
+
+    test('checkoutOptionsCommit survives as the original SHA string', () => {
+      const parser = LockfileParser.readFileSync(filePath);
+      const dg = parser.toDepGraph().toJSON();
+      const node = dg.graph.nodes.find(
+        (n) => n.nodeId === 'AFNetworkActivityLogger'
+      );
+      expect(node!.info!.labels!.checkoutOptionsCommit).toBe(
+        'b7cce59a369788c409d218e8dab7f381a858cee4'
+      );
+      expect(typeof node!.info!.labels!.checkoutOptionsCommit).toBe('string');
+    });
+  });
+
+  describe('synthetic lockfiles with YAML-1.1-coercible scalars', () => {
+    function lockfileWithBranch(branch: string): string {
+      return [
+        'PODS:',
+        '  - SomePod (1.0.0)',
+        'DEPENDENCIES:',
+        '  - SomePod (from `https://example.com/SomePod.git`, branch `' +
+          branch +
+          '`)',
+        'EXTERNAL SOURCES:',
+        '  SomePod:',
+        '    :git: https://example.com/SomePod.git',
+        '    :branch: ' + branch,
+        'SPEC CHECKSUMS:',
+        '  SomePod: 0000000000000000000000000000000000000000',
+        'COCOAPODS: 1.15.2',
+        '',
+      ].join('\n');
+    }
+
+    const cases: Array<[string, string]> = [
+      ['underscored numeric (the AFNetworkActivityLogger case)', '3_0_0'],
+      ['plain integer', '300'],
+      ['floating-point-looking', '1.0'],
+      ['boolean yes', 'yes'],
+      ['boolean no', 'no'],
+      ['boolean true', 'true'],
+      ['null literal', 'null'],
+      ['hex integer', '0x1A'],
+      ['octal integer', '0755'],
+      ['ISO date', '2024-01-01'],
+      ['infinity', '.inf'],
+      ['not-a-number', '.nan'],
+    ];
+
+    test.each(cases)(
+      'branch name `%s` (=%s) round-trips as a string',
+      (_label, branch) => {
+        const parser = LockfileParser.readContents(lockfileWithBranch(branch), {
+          name: 'synthetic',
+          version: '0.0.0',
+        });
+        const dg = parser.toDepGraph().toJSON();
+        const node = dg.graph.nodes.find((n) => n.nodeId === 'SomePod');
+        expect(node).toBeDefined();
+        expect(node!.info!.labels!.externalSourceBranch).toBe(branch);
+        expect(typeof node!.info!.labels!.externalSourceBranch).toBe('string');
+      }
+    );
+  });
+});


### PR DESCRIPTION
### What this does

Fixes an issue seen in production where `AFNetworkActivityLogger` is pinned to branch `3_0_0` ([AFNetworkActivityLogger branch link](https://github.com/AFNetworking/AFNetworkActivityLogger/tree/3_0_0)).

This ensures that `externalSourceBranch` is set to `"3_0_0"` as string, rather than the number `300`.

### Notes for the reviewer

This fix forces all `nodeInfoLabels` to be `string` as per the [types](https://github.com/snyk/cocoapods-lockfile-parser/blob/b0e89873887b26da2a84c3d00587e06619fda7a0/lib/types.ts#L1C18-L22) in `NodeInfoLabels`.

