### PR TITLE
chore: add missing nodejs-install context for release workflow install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ workflows:
             - Test
           context:
             - github-release
+            - nodejs-install
           filters:
             branches:
               only:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The circleci relese workflow needs and NPM_TOKEN to install dependencies first, which comes from the `nodejs-install` circleci context